### PR TITLE
Upgrade PHP_CodeSniffer to v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9",
-        "squizlabs/php_codesniffer": "^3"
+        "squizlabs/php_codesniffer": "^4.0"
     },
     "scripts": {
         "test": "vendor/bin/phpunit test/",


### PR DESCRIPTION
Updates squizlabs/php_codesniffer constraint to ^4.0.