### PR TITLE
Modernize CI workflow and add PHP 8.3/8.4 matrix

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -8,22 +8,34 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version: [ '8.3', '8.4' ]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '8.3'
-
-    - name: Install dependencies
-      run: ./composer.phar install --prefer-dist --no-progress
+        php-version: ${{ matrix.php-version }}
+        coverage: none
+        tools: composer:v2
 
     - name: Validate composer.json and composer.lock
       run: ./composer.phar validate --strict
 
+    - name: Cache Composer packages
+      uses: actions/cache@v4
+      with:
+        path: vendor
+        key: ${{ runner.os }}-php-${{ matrix.php-version }}-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-php-${{ matrix.php-version }}-
+
+    - name: Install dependencies
+      run: ./composer.phar install --prefer-dist --no-progress
+
     - name: Run test suite
-      run: ./vendor/bin/phpunit test/
+      run: ./composer.phar test


### PR DESCRIPTION
Updates GitHub Actions and runs tests on PHP 8.3 and 8.4 with versioned cache keys.